### PR TITLE
Use Record.getMessage to implement user formatting in log messages.

### DIFF
--- a/splunk_hec_handler/__init__.py
+++ b/splunk_hec_handler/__init__.py
@@ -132,7 +132,8 @@ class SplunkHecHandler(logging.Handler):
                 body.update({'message': ast.literal_eval(str(record.msg))})
         except Exception as err:
             logging.debug("Log record emit exception raised. Exception: %s " % err)
-            body.update({'message': record.msg})
+            message = record.getMessage()
+            body.update({'message': message})
 
         event = dict({'host': self.hostname, 'event': body, 'fields': {}})
 


### PR DESCRIPTION
When falling back to using `record.msg` as a string, let's instead use `Record.getMessage()` which returns a string that has has the user-formatting applied. This allows %-style formatting to work as shown below.

```python
import logging
from splunk_hec_handler import SplunkHecHandler
logger = logging.getLogger('SplunkHecHandlerExample')
logger.setLevel(logging.INFO)

# If using self-signed certificate, set ssl_verify to False
# If using http, set proto to http
splunk_handler = SplunkHecHandler('splunkfw.domain.tld',
                    'EA33046C-6FEC-4DC0-AC66-4326E58B54C3',
                    port=8888, proto='https', ssl_verify=True,
                    source="HEC_example")
logger.addHandler(splunk_handler)

name = "scooby"
age = 10
logger.info("Name is %s and age is %d", name, age)
```